### PR TITLE
Add subheader to category sections, update copy

### DIFF
--- a/_articles/index.md
+++ b/_articles/index.md
@@ -2,6 +2,7 @@
 title: Articles
 layout: index
 ---
+<center> These are the main instructions for using Synapse on the web and through the programmatic clients. Pick an area that interests you, or read them in order, to improve your knowledge of Synapse. </center>
 
 <!-- {% assign doclist = site.pages | sort: 'order' %} -->
 {% assign categories = site.categories | sort: "order" %}
@@ -30,6 +31,7 @@ layout: index
     <div class="tab-pane active" id="{{ category.name }}">
 
     <h3>{{ category.title }}</h3>
+    <h4>{{ category.explanation }}</h4>
     {% for group in groups %} {% if group.name contains category.name %}
     <ul>
     {% assign pages = group.items | sort: "order" %}

--- a/_categories/get-started.md
+++ b/_categories/get-started.md
@@ -1,6 +1,7 @@
 ---
 name: get-started
-title: Get Started
-excerpt: Get started with Synapse.
+title: Before you start
+excerpt: New to Synapse? Read this 10 minute guide that explains what it is, why you should use it, and how to get started!
+explanation: Read these articles first to get a better understanding of Synapse.
 order: 1
 ---

--- a/_categories/governance.md
+++ b/_categories/governance.md
@@ -1,6 +1,6 @@
 ---
 name: governance
 title: Governance
-excerpt: Stuff about governance.
+excerpt: Requirements and best practices for using Synapse in a compliant and ethical manner.
 order: 3
 ---


### PR DESCRIPTION
I labeled this as a draft because it is still pretty rough.

@kdaily I added an `<h4>` `explanation` category metadata variable to enter the sub-section text as [displayed in the figma design](https://www.figma.com/proto/6x2gb3yOgOABbs6WrIw5Us/Docs?node-id=414%3A1378&viewport=-169%2C476%2C0.04919316992163658&scaling=min-zoom). 

It seems like we may need a 3rd index page to contain the listed pages e.g.:
https://github.com/Sage-Bionetworks/synapseDocs/pull/678/files#diff-74c3149c514fda34d73a2fefea9b8ca4R37-R39 and instead embed the subject cards here within the categories. 

Overall, we will have to work on the styling. For example, centering the page text in _articles/index.md isn't enough to make it look aesthetically pleasing. 