### PR TITLE
Update categories to match wire-frame

### DIFF
--- a/_categories/API-client.md
+++ b/_categories/API-client.md
@@ -1,6 +1,8 @@
 ---
 name: API-client
-title: API clients
+title: API Clients
 excerpt: Using the Synapse clients and REST API.
-order: 5
+explanation: Using the Synapse clients and REST API.
+section: core-components
+order: 6
 ---

--- a/_categories/admin-and-settings.md
+++ b/_categories/admin-and-settings.md
@@ -1,0 +1,8 @@
+---
+name: admin-and-settings
+title: Administration and Settings
+excerpt: These topics will help you learn about useful settings in Synapse.
+explanation: These topics will help you learn about useful settings in Synapse.
+section: core-components
+order: 5
+---

--- a/_categories/challenges.md
+++ b/_categories/challenges.md
@@ -1,0 +1,8 @@
+---
+name: challenges
+title: Challenges
+excerpt: Synapse is being used to run Scientific Computing Challenges. Use these articles to find out more!
+explanation: Synapse is being used to run Scientific Computing Challenges. Use these articles to find out more!
+section: additional-components
+order: 3
+---

--- a/_categories/collaboration-and-communication.md
+++ b/_categories/collaboration-and-communication.md
@@ -1,0 +1,8 @@
+---
+name: collaboration-and-communication
+title: Collaboration and Communication
+excerpt: Synapse is a collaborative platform. Learn about tools that allow this, such as Discussion threads and Wikis.
+explanation: Synapse is a collaborative platform. Learn about tools that allow this, such as Discussion threads and Wikis.
+section: core-components
+order: 3
+---

--- a/_categories/get-started.md
+++ b/_categories/get-started.md
@@ -1,7 +1,8 @@
 ---
 name: get-started
-title: Before you start
+title: Getting Started
 excerpt: New to Synapse? Read this 10 minute guide that explains what it is, why you should use it, and how to get started!
 explanation: Read these articles first to get a better understanding of Synapse.
+section: before-you-start
 order: 1
 ---

--- a/_categories/governance.md
+++ b/_categories/governance.md
@@ -2,5 +2,7 @@
 name: governance
 title: Governance
 excerpt: Requirements and best practices for using Synapse in a compliant and ethical manner.
+explanation: Requirements and best practices for using Synapse in a compliant and ethical manner.
+section: before-you-start
 order: 3
 ---

--- a/_categories/how-to.md
+++ b/_categories/how-to.md
@@ -1,6 +1,0 @@
----
-name: how-to
-title: How To
-excerpt: Articles about Synapse.
-order: 2
----

--- a/_categories/in-practice.md
+++ b/_categories/in-practice.md
@@ -1,6 +1,0 @@
----
-name: in-practice
-title: In Practice
-excerpt: Using Synapse in the Real World.
-order: 4
----

--- a/_categories/managing-data.md
+++ b/_categories/managing-data.md
@@ -1,0 +1,8 @@
+---
+name: managing-data
+title: Managing Data in Synapse
+excerpt: Synapse is a collaborative platform. Learn about tools that allow this, such as Discussion threads and Wikis.
+explanation: Synapse is a collaborative platform. Learn about tools that allow this, such as Discussion threads and Wikis.
+section: core-components
+order: 2
+---

--- a/_categories/metadata-and-annotations.md
+++ b/_categories/metadata-and-annotations.md
@@ -1,0 +1,8 @@
+---
+name: metadata-and-annotations
+title: Metadata and Annotations
+excerpt: Annotations are a method to systematically group and/or describe things in Synapse.
+explanation: Annotations are a method to systematically group and/or describe things in Synapse.
+section: additional-components
+order: 1
+---

--- a/_categories/projects.md
+++ b/_categories/projects.md
@@ -1,0 +1,8 @@
+---
+name: projects
+title: Synapse Projects
+excerpt: All content in Synapse is stored within Projects. Learn more about Projects and how to use them for uploading, downloading, and managing content, such as data files.
+explanation: All content in Synapse is stored within Projects. Learn more about Projects and how to use them for uploading, downloading, and managing content, such as data files.
+section: core-components
+order: 1
+---

--- a/_categories/reproducible-research.md
+++ b/_categories/reproducible-research.md
@@ -1,0 +1,8 @@
+---
+name: reproducible-research
+title: Reproducible Research
+excerpt: Synapse is a collaborative platform. Learn about tools that allow this, such as Discussion threads and Wikis.
+explanation: Synapse is a collaborative platform. Learn about tools that allow this, such as Discussion threads and Wikis.
+section: additional-components
+order: 2
+---

--- a/_categories/search-and-discovery.md
+++ b/_categories/search-and-discovery.md
@@ -1,0 +1,8 @@
+---
+name: search-and-discovery
+title: Search and Discovery
+excerpt: You can use Synapse to find people, teams, and intereseting projects.
+explanation: You can use Synapse to find people, teams, and intereseting projects.
+section: core-components
+order: 4
+---

--- a/_categories/synapse-101.md
+++ b/_categories/synapse-101.md
@@ -1,0 +1,8 @@
+---
+name: synapse-101
+title: Synapse 101
+excerpt: Get a brief overview of some of the main components of Synapse, including Projects, _____, _____.
+explanation: Get a brief overview of some of the main components of Synapse, including Projects, _____, _____.
+section: before-you-start
+order: 2
+---


### PR DESCRIPTION
Updated the categories to match the wire-frame ones. I removed a couple that were not in the wire-frame cards, how-to and in-practice. The rest were named after the cards with minor adjustments if it made sense to shorten them (e.g. "synapse-projects" became the category "projects" with the title "Synapse Projects"). The excerpts were copied from the wire-frame cards and many could use updating. Explanations are just copy/paste of the excerpt for now.

The articles still need to be updated to have the correct category.

I did notice when I built it locally that the categories are not getting filtered into their respective sections.