### PR TITLE
Update tags on articles

### DIFF
--- a/_articles/accounts_certified_users_and_profile_validation.md
+++ b/_articles/accounts_certified_users_and_profile_validation.md
@@ -2,7 +2,7 @@
 title: "User Types including Certified Users"
 layout: article
 excerpt: Find out about the three levels of Synapse users and the privileges and responsibilities associated with each level.
-category: governance
+category: [governance, synapse-101]
 order: 3
 ---
 

--- a/_articles/annotation_and_query.md
+++ b/_articles/annotation_and_query.md
@@ -2,7 +2,7 @@
 title: Annotations and Queries
 layout: article
 excerpt: Learn about using custom metadata, how to assign and modify annotations, and how to query them for analysis. 
-category: how-to
+category: metadata-and-annotations
 ---
 
 `Annotations` are key-value pairs stored as metadata for `Projects`, `Files`, `Folders`, and `Tables` that help users to find and query data. Annotations can be based on an existing ontology or controlled vocabulary, or can be created in an *ad hoc* manner and modified later as the metadata evolves. Annotations can be a powerful tool used to systematically group and/or describe things (files or data, etc.) in Synapse, which then provides a way for those things to be searched for and discovered.

--- a/_articles/api_documentation.md
+++ b/_articles/api_documentation.md
@@ -2,6 +2,7 @@
 title: API Documentation
 description: Technical documentation for using the Python, R, command line clients and RESTful APIs.
 layout: index
+category: API-client
 ---
 
 

--- a/_articles/challenge_administration.md
+++ b/_articles/challenge_administration.md
@@ -2,7 +2,7 @@
 title: Challenge Infrastructure
 layout: article
 excerpt: Learn how to set-up the wireframe of a challenge. 
-category: how-to
+category: challenges
 ---
 
 This guide is meant to help organizers create a **challenge space** within Synapse to host a crowd-sourced challenge. A challenge space provides participants with a `Project` to learn about the challenge, join the challenge community, submit entries, track progress and view results.  This document will focus on:

--- a/_articles/challenge_participation.md
+++ b/_articles/challenge_participation.md
@@ -2,7 +2,7 @@
 title: Participating in a Challenge
 layout: article
 excerpt: Learn how to participate in challenges.
-category: how-to
+category: challenges
 ---
 
 <style>

--- a/_articles/custom_storage_location.md
+++ b/_articles/custom_storage_location.md
@@ -2,7 +2,7 @@
 title: "Custom Storage Locations"
 layout: article
 excerpt: Follow these steps to set up custom storage locations and access them with Synapse. 
-category: how-to
+category: admin-and-settings
 ---
 
 <style>

--- a/_articles/discussion.md
+++ b/_articles/discussion.md
@@ -2,7 +2,7 @@
 title: Discussion Forums
 layout: article
 excerpt: Explore the features of the discussion forum and how to use it to help your collaborations.
-category: how-to
+category: [collaboration-and-communication, synapse-101]
 ---
 
 <style>

--- a/_articles/docker.md
+++ b/_articles/docker.md
@@ -2,7 +2,7 @@
 title: Synapse Docker Registry
 layout: article
 excerpt: The Synapse Docker registry provides a space for Synapse users to store and distribute their Docker images per Synapse project.
-category: how-to
+category: reproducible-research
 ---
 
 Docker is a tool for creating, running, and managing lightweight virtual machines. These virtual machines make it possible to distribute executable environments with all of the dependencies that can easily be run by others. These Docker images can then be stored and distributed on a Docker registry, a collection of these images. There are a number of open registries on the web, and Synapse hosts a private registry, freely available to our users, which will allow users to create software on a per project basis which can be easily shared across Synapse. Learn more about [Docker](https://www.docker.com/products/overview) and [Docker registry](https://www.docker.com/products/docker-registry).

--- a/_articles/doi.md
+++ b/_articles/doi.md
@@ -2,7 +2,7 @@
 title: "Digital Object Identifiers (DOIs) in Synapse"
 layout: article
 excerpt: Mint DOIs in Synapse to cite your research.
-category: how-to
+category: reproducible-research
 ---
 
 <style>

--- a/_articles/downloading_data.md
+++ b/_articles/downloading_data.md
@@ -2,7 +2,7 @@
 title: "Downloading Data"
 layout: article
 excerpt: Learn the best practices of finding and downloading files.
-category: get-started
+category: managing-data
 order: 3
 ---
 

--- a/_articles/edit_wiki_order.md
+++ b/_articles/edit_wiki_order.md
@@ -2,7 +2,7 @@
 title: "Editing Wiki Page Order"
 layout: article
 excerpt: Organize wiki pages into a sensible hierarchy
-category: how-to
+category: collaboration-and-communication
 ---
 
 `Wikis` provide a space to write narrative content to describe a project or content within the project. They are available in Synapse on `Projects`, `Folders`, and `Files`. Sometimes, as wikis evolve, the page order needs to be modified to better suit the overall project strucutre. This article details how to do this.

--- a/_articles/evaluation_queues.md
+++ b/_articles/evaluation_queues.md
@@ -3,7 +3,7 @@
 title: Evaluation Queues
 layout: article
 excerpt: An queue accepts submission of Synapse entities for evaluation. 
-category: how-to
+category: reproducible-research
 ---
 
 An Evaluation queue allows for people to submit Synapse `Files`, `Docker` images, etc. for evaluation. They are designed to support open-access data analysis and modeling challenges in Synapse. This framework provides tools for administrators to collect and analyze data models from Synapse users created for a specific goal or purpose.

--- a/_articles/files_and_versioning.md
+++ b/_articles/files_and_versioning.md
@@ -2,7 +2,7 @@
 title: Files and Versioning
 layout: article
 excerpt: Uploading and managing files and versions in Synapse.
-category: how-to
+category: managing-data
 ---
 
 <style>

--- a/_articles/getting_started_clients.md
+++ b/_articles/getting_started_clients.md
@@ -2,7 +2,7 @@
 title: "Getting Started with the Synapse API Clients"
 layout: article
 excerpt: Use Synapse programmatically.
-category: [API-client, getting-started]
+category: [API-client, synapse-101]
 order: 1
 ---
 

--- a/_articles/governance.md
+++ b/_articles/governance.md
@@ -2,7 +2,7 @@
 title: Governance Overview
 layout: article
 excerpt: A look at the Synapse governance process.
-category: governance
+category: [governance, synapse-101]
 order: 1
 ---
 

--- a/_articles/making_a_project.md
+++ b/_articles/making_a_project.md
@@ -2,7 +2,7 @@
 title: Making a Project
 layout: article
 excerpt: An overview of Synapse Projects.
-category: how-to
+category: [projects, synapse-101]
 order: 2
 ---
 

--- a/_articles/managing_custom_metadata_at_scale.md
+++ b/_articles/managing_custom_metadata_at_scale.md
@@ -2,7 +2,7 @@
 title: Managing Custom Metadata at Scale
 layout: article
 excerpt: Update metadata in bulk using file views and programmatic clients.
-category: in-practice
+category: metadata-and-annotations
 ---
 
 This vignette will combine concepts from [Annotations and Queries](annotation_and_query.md), [Views](views.md), [Uploading and Downloading Data in Bulk](uploading_in_bulk.md) in order to **create a manifest** `velociraptor_manifest.txt`, **upload** 100 files and **edit** annotations on these files using the Synapse clients.


### PR DESCRIPTION
Update most tags on articles from A-M.

Articles that need updated tags in this section are:
- forms
- genome-browser
- links
- managing_teams_for_groups_and_projects (currently in-practice, but seems like should be elsewhere)
- FAQ (left in get-started)